### PR TITLE
feat: add admin boat selection modal

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -68,7 +68,7 @@ export default async function handler(req, res) {
         id: 'global-user',
         name: `Global User (${imei})`,
         role: 'admin',
-        imeis: [imei],
+        imeis: [],
       });
     }
     

--- a/server/server.js
+++ b/server/server.js
@@ -77,7 +77,7 @@ app.post('/api/auth/login', async (req, res) => {
         id: 'global-user',
         name: `Global User (${imei})`,
         role: 'admin',
-        imeis: [imei],
+        imeis: [],
       });
     }
     

--- a/src/components/BoatSelectionModal.tsx
+++ b/src/components/BoatSelectionModal.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { fetchLiveLocations } from '../api/pelagicDataService';
+import { LiveLocation } from '../types';
+import { formatDateTime } from '../utils/formatters';
+
+interface BoatSelectionModalProps {
+  onSelect: (imei: string) => void;
+  onClose: () => void;
+}
+
+const BoatSelectionModal: React.FC<BoatSelectionModalProps> = ({ onSelect, onClose }) => {
+  const { t } = useTranslation();
+  const [boats, setBoats] = useState<LiveLocation[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadBoats = async () => {
+      try {
+        setLoading(true);
+        const data = await fetchLiveLocations();
+        setBoats(data);
+      } catch (err) {
+        console.error('Error loading vessels:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadBoats();
+  }, []);
+
+  return (
+    <div className="modal d-block" style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}>
+      <div className="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+        <div className="modal-content">
+          <div className="modal-header">
+            <h3 className="modal-title">{t('navigation.selectBoat')}</h3>
+            <button type="button" className="btn-close" onClick={onClose}></button>
+          </div>
+          <div className="modal-body">
+            {loading ? (
+              <div className="d-flex justify-content-center py-5">
+                <div className="spinner-border text-primary" role="status">
+                  <span className="visually-hidden">{t('common.loading')}</span>
+                </div>
+              </div>
+            ) : (
+              <div className="table-responsive">
+                <table className="table table-hover">
+                  <thead>
+                    <tr>
+                      <th>{t('vessel.name')}</th>
+                      <th>{t('vessel.imei')}</th>
+                      <th>{t('vessel.lastPosition')}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {boats.map((boat) => (
+                      <tr key={boat.imei} style={{ cursor: 'pointer' }} onClick={() => onSelect(boat.imei)}>
+                        <td>{boat.boatName || t('common.unknown')}</td>
+                        <td>{boat.imei}</td>
+                        <td>{boat.lastSeen ? formatDateTime(new Date(boat.lastSeen)) : t('common.never')}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BoatSelectionModal;

--- a/src/hooks/useTripData.ts
+++ b/src/hooks/useTripData.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Trip, TripPoint, TripPointsParams, TripsParams } from '../types';
+import { Trip, TripPoint } from '../types';
 import { fetchTrips, fetchTripPoints, fetchLiveLocations } from '../api/pelagicDataService';
 import { useAuth } from '../contexts/AuthContext';
 
@@ -26,12 +26,20 @@ export const useTripData = (
   const fetchData = async () => {
     if (!currentUser) return;
 
+    const imeis = currentUser.imeis;
+    if (!imeis || imeis.length === 0) {
+      setTrips([]);
+      setTripPoints([]);
+      setDataAvailable(false);
+      setErrorMessage(null);
+      setLoading(false);
+      return;
+    }
+
     setLoading(true);
     setErrorMessage(null);
 
     try {
-      const imeis = currentUser.imeis;
-
       console.log('Fetching trip data with IMEIs:', imeis);
       console.log('Date range:', dateFrom, dateTo);
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -95,7 +95,8 @@
     "logout": "Logout",
     "profile": "Profile",
     "settings": "Settings",
-    "language": "Language"
+    "language": "Language",
+    "selectBoat": "Select Boat"
   },
   "auth": {
     "loginTitle": "Login to your account",
@@ -128,7 +129,10 @@
     "loadingData": "Loading tracking data...",
     "errorLoadingData": "Error loading tracking data. Please try again.",
     "noImeiData": "No IMEI data available for this user.",
-    "noImeiDataMessage": "Please contact your administrator to set up IMEI tracking for your account."
+    "noImeiDataMessage": "Please contact your administrator to set up IMEI tracking for your account.",
+    "noVesselSelected": "No vessel selected. Please choose a boat to view tracking data.",
+    "noDataForImei": "No tracking data is available for your IMEI: {{imei}}",
+    "noDataForImeis": "No tracking data is available for your IMEIs: {{imeis}}"
   },
   "vessel": {
     "name": "Vessel Name",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -95,7 +95,8 @@
     "logout": "Sair",
     "profile": "Perfil",
     "settings": "Configurações",
-    "language": "Idioma"
+    "language": "Idioma",
+    "selectBoat": "Selecionar Embarcação"
   },
   "auth": {
     "loginTitle": "Entrar na sua conta",
@@ -128,7 +129,10 @@
     "loadingData": "Carregando dados de rastreamento...",
     "errorLoadingData": "Erro ao carregar dados de rastreamento. Tente novamente.",
     "noImeiData": "Nenhum dado IMEI disponível para este usuário.",
-    "noImeiDataMessage": "Entre em contato com o administrador para configurar o rastreamento IMEI para sua conta."
+    "noImeiDataMessage": "Entre em contato com o administrador para configurar o rastreamento IMEI para sua conta.",
+    "noVesselSelected": "Nenhuma embarcação selecionada. Por favor, escolha um barco para ver os dados de rastreamento.",
+    "noDataForImei": "Nenhum dado de rastreamento disponível para o seu IMEI: {{imei}}",
+    "noDataForImeis": "Nenhum dado de rastreamento disponível para seus IMEIs: {{imeis}}"
   },
   "vessel": {
     "name": "Nome da Embarcação",

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from 'react';
-import { IconUser, IconSun, IconMoon, IconLogout, IconChevronDown } from '@tabler/icons-react';
+import { IconUser, IconSun, IconMoon, IconLogout, IconChevronDown, IconShip } from '@tabler/icons-react';
 import { useAuth } from '../contexts/AuthContext';
 import { useTranslation } from 'react-i18next';
 import LanguageSwitcher from '../components/LanguageSwitcher';
 import MobileLanguageToggle from '../components/MobileLanguageToggle';
+import BoatSelectionModal from '../components/BoatSelectionModal';
 
 interface MainLayoutProps {
   children: React.ReactNode;
@@ -12,9 +13,10 @@ interface MainLayoutProps {
 }
 
 const MainLayout: React.FC<MainLayoutProps> = ({ children, pageHeader, stickyFooter }) => {
-  const { logout, currentUser } = useAuth();
+  const { logout, currentUser, updateUserImeis } = useAuth();
   const { t } = useTranslation();
   const [darkMode, setDarkMode] = useState(false);
+  const [showBoatSelection, setShowBoatSelection] = useState(false);
   
   // Initialize dark mode from localStorage on component mount
   useEffect(() => {
@@ -120,6 +122,12 @@ const MainLayout: React.FC<MainLayoutProps> = ({ children, pageHeader, stickyFoo
                     </div>
                   )}
                 </div>
+                {currentUser?.role === 'admin' && (
+                  <a href="#" className="dropdown-item" onClick={() => setShowBoatSelection(true)}>
+                    <IconShip size={16} className="me-2" />
+                    {t('navigation.selectBoat')}
+                  </a>
+                )}
                 <div className="dropdown-divider"></div>
                 <a href="#" className="dropdown-item" onClick={handleLogout}>
                   <IconLogout size={16} className="me-2" />
@@ -150,12 +158,12 @@ const MainLayout: React.FC<MainLayoutProps> = ({ children, pageHeader, stickyFoo
       
       {/* Sticky Footer */}
       {stickyFooter && (
-        <div className="sticky-footer bg-body border-top shadow-lg d-print-none" 
-             style={{ 
-               position: 'fixed', 
-               bottom: 0, 
-               left: 0, 
-               right: 0, 
+        <div className="sticky-footer bg-body border-top shadow-lg d-print-none"
+             style={{
+               position: 'fixed',
+               bottom: 0,
+               left: 0,
+               right: 0,
                zIndex: 1030,
                backdropFilter: 'blur(10px)'
              }}
@@ -164,6 +172,15 @@ const MainLayout: React.FC<MainLayoutProps> = ({ children, pageHeader, stickyFoo
             {stickyFooter}
           </div>
         </div>
+      )}
+      {showBoatSelection && (
+        <BoatSelectionModal
+          onSelect={(imei) => {
+            updateUserImeis([imei]);
+            setShowBoatSelection(false);
+          }}
+          onClose={() => setShowBoatSelection(false)}
+        />
       )}
     </div>
   );

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -5,8 +5,8 @@ import TripsTable from '../components/TripsTable';
 import { IconCalendarStats, IconFish } from '@tabler/icons-react';
 import { useAuth } from '../contexts/AuthContext';
 import { useTranslation } from 'react-i18next';
-import { subDays, format, differenceInDays } from 'date-fns';
-import { Trip, TripPoint, LiveLocation } from '../types';
+import { subDays, differenceInDays } from 'date-fns';
+import { Trip } from '../types';
 import { calculateVesselInsights } from '../utils/calculations';
 import { formatDisplayDate } from '../utils/formatters';
 import { renderNoImeiDataMessage } from '../utils/userInfo';
@@ -43,15 +43,9 @@ const Dashboard: React.FC = () => {
     refetch: refetchTripData
   } = useTripData(dateFrom, dateTo);
 
-  const {
-    liveLocations,
-    loading: liveLocationsLoading,
-    error: liveLocationsError,
-    refetch: refetchLiveLocations
-  } = useLiveLocations();
+  const { liveLocations } = useLiveLocations();
 
   const {
-    selectedVessel,
     selectedTripId,
     handleSelectVessel: originalHandleSelectVessel,
     handleSelectTrip: originalHandleSelectTrip,
@@ -59,7 +53,7 @@ const Dashboard: React.FC = () => {
   } = useVesselSelection(trips, tripPoints, liveLocations);
 
   // Wrapper for handleSelectVessel that also resets live location view
-  const handleSelectVessel = (vessel: any) => {
+  const handleSelectVessel = (vessel: { id: string; name: string } | null) => {
     originalHandleSelectVessel(vessel);
     setIsViewingLiveLocations(false);
   };
@@ -96,12 +90,11 @@ const Dashboard: React.FC = () => {
     setIsViewingLiveLocations(false);
   };
 
-  // Handle preset date range selections
-  const handlePresetDateRange = (days: number) => {
-    const newDateTo = new Date();
-    const newDateFrom = subDays(newDateTo, days);
-    handleDateChange(newDateFrom, newDateTo);
-  };
+  const imeiKey = currentUser?.imeis.join(',');
+  // Clear any selection when the accessible IMEIs change (e.g., admin selects a new boat)
+  useEffect(() => {
+    clearSelection();
+  }, [clearSelection, imeiKey]);
 
   // Function to center map on live locations
   const centerOnLiveLocations = () => {
@@ -208,7 +201,7 @@ const Dashboard: React.FC = () => {
               onSelectVessel={handleSelectVessel}
               onRetry={refetchTripData}
               onTryWiderDateRange={() => handleDateChange(subDays(new Date(), 90), new Date())}
-              renderNoImeiDataMessage={() => renderNoImeiDataMessage(currentUser)}
+              renderNoImeiDataMessage={() => renderNoImeiDataMessage(currentUser, t)}
               isViewingLiveLocations={isViewingLiveLocations}
               onCenterOnLiveLocations={centerOnLiveLocations}
             />
@@ -304,7 +297,7 @@ const Dashboard: React.FC = () => {
               onSelectVessel={handleSelectVessel}
               onRetry={refetchTripData}
               onTryWiderDateRange={() => handleDateChange(subDays(new Date(), 90), new Date())}
-              renderNoImeiDataMessage={() => renderNoImeiDataMessage(currentUser)}
+              renderNoImeiDataMessage={() => renderNoImeiDataMessage(currentUser, t)}
               isViewingLiveLocations={isViewingLiveLocations}
               onCenterOnLiveLocations={centerOnLiveLocations}
             />

--- a/src/utils/userInfo.ts
+++ b/src/utils/userInfo.ts
@@ -1,24 +1,28 @@
 import { User } from '../contexts/AuthContext';
+import { TFunction } from 'i18next';
 
 /**
  * Render "No data" message for the specified IMEI
  */
-export const renderNoImeiDataMessage = (currentUser: User | null): string => {
-  if (!currentUser) return "No vessel data is available.";
-  
+export const renderNoImeiDataMessage = (currentUser: User | null, t: TFunction): string => {
+  if (!currentUser) return t('dashboard.noVesselSelected');
+
   if (currentUser.role === 'admin') {
-    return "No tracking data is available for the selected date range.";
+    if (!currentUser.imeis || currentUser.imeis.length === 0) {
+      return t('dashboard.noVesselSelected');
+    }
+    return t('dashboard.noDataMessage');
   }
-  
+
   const imeis = currentUser.imeis || [];
   const imeiCount = imeis.length;
-  
+
   if (imeiCount === 0) {
-    return "No vessel IMEIs are associated with your account.";
+    return t('dashboard.noImeiDataMessage');
   } else if (imeiCount === 1) {
-    return `No tracking data is available for your IMEI: ${imeis[0]}`;
+    return t('dashboard.noDataForImei', { imei: imeis[0] });
   } else {
-    return `No tracking data is available for your IMEIs: ${imeis.join(', ')}`;
+    return t('dashboard.noDataForImeis', { imeis: imeis.join(', ') });
   }
 };
 


### PR DESCRIPTION
## Summary
- add admin-only vessel picker modal and menu item
- avoid fetching trip data when no boat is selected
- expose updateUserImeis in auth context and clear selection on vessel change

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars, etc.)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd8fb4cee4832989fd7452de311fcf