### PR TITLE
Fix waypoint retrieval to query by IMEI instead of userId

### DIFF
--- a/server/config/database.js
+++ b/server/config/database.js
@@ -1,4 +1,15 @@
 import { MongoClient } from 'mongodb';
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Get current file directory for proper path resolution
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Load environment variables BEFORE accessing process.env
+// This is necessary because ES modules load dependencies before the main file
+dotenv.config({ path: path.join(__dirname, '..', '..', '.env') });
 
 // MongoDB Connection
 // Remove quotes from MongoDB URI if present


### PR DESCRIPTION
- Updated waypoint GET endpoints to support IMEI as a query parameter
- Backend now looks up user's IMEI when given userId and queries waypoints by IMEI
- This fixes the issue where waypoints weren't showing for PDS users whose userId changed
- Added dotenv loading to database.js to fix MongoDB connection in local dev
- Maintains backward compatibility with userId and username queries

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Waypoint GET endpoints now query by IMEI (with userId->IMEI fallback) and database config loads environment variables for local/dev reliability.
> 
> - **Waypoints retrieval (API & Express)**:
>   - Accept `imei` query param and prioritize lookup order: `imei` → `userId` (with user `IMEI` lookup) → `username`.
>   - When `userId` is provided, attempt user lookup to use `user.IMEI`; otherwise fall back to `userId` (handling both `ObjectId` and string forms).
>   - Always filter by `isPrivate: true`; add targeted logging.
> - **Database configuration**:
>   - Load `.env` via `dotenv` in `server/config/database.js` (with ESM-safe path resolution) before reading `process.env` and mask logged MongoDB URI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60bcd10a5a7eb3e0c5391c296d66cd89f493df73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->